### PR TITLE
Document default credentials and where to change them

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,48 @@ Aka telnet server in the nodemcu examples, but rewritten as a module for the tcp
 Allows easy upload of files over the network (as opposed to the serial port). Joint work with Rene van der Zee.
 
 ### Webpage front-end
-A wifi gui to configure all wifi parameters, a garage door opener app (original example by Marcos Kirsch), other example webpages.
+
+  - A wifi GUI to configure all wifi parameters.
+  - A garage door opener app (original example by Marcos Kirsch).
+  - Other example webpages.
 
 ## Installation
-  1. Flash nodemcu firmware
-  2. file.format()
-  3. Upload all files in this repo (except maybe the README) using ESPlorer or similar, including those in the http dir (don't worry about the dir name)
+  1. [Flash nodemcu firmware](https://nodemcu.readthedocs.io/en/dev/en/flash/)
+  2. Clear the filesystem: `file.format()`
+  3. Upload all files in this repo (except maybe the README) using ESPlorer or similar, including those in the `http` directory (don't worry about the dir name, the `init.lua` triggers these files to be renamed to `http/*` on the flash)
   4. Reboot nodemcu
-  5. Connect to ESP-someid wifi hotspot
+  5. Connect to ESP-someid wifi hotspot and visit <http://192.168.111.1>
   6. Follow Wifi Configuration, edit wifi parameters to your liking, Submit
- 
+
+### Default credentials and where to change them
+
+Out of the box, the platform sets up the following resources and credentials that you will likely want to change after you try out a test run:
+
+#### A WiFi access point – `wifi-confmakedefault.lua`
+
+  - SSID: `ESP-<chip ID>`
+  - Password: `theballismine`
+  - Gateway IP: 192.168.111.1
+
+#### WiFi station joining – `wifi-confmakedefault.lua`
+
+Joining an existing WiFi network. This can be changed from the web UI, but you likely want a default for your project development.
+
+  - SSID: `devnet`
+  - Password: `theballismine`
+
+#### Web UI for WiFi configuration – `httpserver-confmakedefault.lua`
+
+  - <http://192.168.111.1>
+  - Basic Auth username: `develo`
+  - Basic Auth password: `theballismine`
+
+#### luaserver, the NodeMCU Lua REPL over telnet
+
+    $ telnet 192.168.111.1 80
+
+Send a carriage return or line feed as the first input after connecting. The `tcpserver` interprets this as a request for the `luaserver` instead of the `httpserver`. You should see a welcome message and prompt.
+
 ## Application development guidelines
 The idea behind this platform is to allow focus on the development of your own application, and reduce your worrying about things like wifi setup, compiling lua, or remote communication.
 Some comments and guidelines:
@@ -50,5 +82,5 @@ Some comments and guidelines:
 ## Planned work
   1. Websocket server module, to run alongside the httpserver module
   2. Modbus server module
-  3. Additional webguis
+  3. Additional web UIs
  

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Allows easy upload of files over the network (as opposed to the serial port). Jo
   2. Clear the filesystem: `file.format()`
   3. Upload all files in this repo (except maybe the README) using ESPlorer or similar, including those in the `http` directory (don't worry about the dir name, the `init.lua` triggers these files to be renamed to `http/*` on the flash)
   4. Reboot nodemcu
-  5. Connect to ESP-someid wifi hotspot and visit <http://192.168.111.1>
+  5. Connect to ESP-someid wifi hotspot and visit <http://192.168.4.1>
   6. Follow Wifi Configuration, edit wifi parameters to your liking, Submit
 
 ### Default credentials and where to change them
@@ -47,7 +47,7 @@ Out of the box, the platform sets up the following resources and credentials tha
 
   - SSID: `ESP-<chip ID>`
   - Password: `theballismine`
-  - Gateway IP: 192.168.111.1
+  - Gateway IP: 192.168.4.1
 
 #### WiFi station joining – `wifi-confmakedefault.lua`
 
@@ -58,13 +58,13 @@ Joining an existing WiFi network. This can be changed from the web UI, but you l
 
 #### Web UI for WiFi configuration – `httpserver-confmakedefault.lua`
 
-  - <http://192.168.111.1>
+  - <http://192.168.4.1>
   - Basic Auth username: `develo`
   - Basic Auth password: `theballismine`
 
 #### luaserver, the NodeMCU Lua REPL over telnet
 
-    $ telnet 192.168.111.1 80
+    $ telnet 192.168.4.1 80
 
 Send a carriage return or line feed as the first input after connecting. The `tcpserver` interprets this as a request for the `luaserver` instead of the `httpserver`. You should see a welcome message and prompt.
 

--- a/wifi-confmakedefault.lua
+++ b/wifi-confmakedefault.lua
@@ -16,14 +16,14 @@ wifiConfig.accessPointConfig.max = 4 -- max clients: 1-4
 wifiConfig.accessPointConfig.beacon = 100 -- beacon interval 100-60000
 
 wifiConfig.accessPointIpConfig = {}
-wifiConfig.accessPointIpConfig.ip = "192.168.111.1"
+wifiConfig.accessPointIpConfig.ip = "192.168.4.1"
 wifiConfig.accessPointIpConfig.netmask = "255.255.255.0"
-wifiConfig.accessPointIpConfig.gateway = "192.168.111.1"
+wifiConfig.accessPointIpConfig.gateway = "192.168.4.1"
 wifiConfig.accessPointIpConfig.mac = wifi.ap.getmac() -------------------- wifi.ap.setmac()
 
 wifiConfig.accessPointDHCPConfig = {}
 wifiConfig.accessPointDHCPConfig.enabled = 1 -------------------------wifi.ap.dhcp.start()/stop()
-wifiConfig.accessPointDHCPConfig.start = "192.168.111.100"
+wifiConfig.accessPointDHCPConfig.start = "192.168.4.100"
 
 wifiConfig.stationPointConfig = {}
 wifiConfig.stationPointConfig.ssid = "devnet"        -- Name of the WiFi network you want to join


### PR DESCRIPTION
Hi,

Thanks for putting this together and sharing it, I'm just getting started with NodeMCU and it's a helpful reference and building block.

This change adds info to the README about how to find and access the resources that are available out of the box. It's not hard to discover this by walking through the code, but it saves time for a new user getting started. I was repeatedly fumbling to find credentials the first time through, like the HTTP Basic auth on the wifi web UI.

I also changed the default IP to 192.168.4.1—since this is a default on fresh NodeMCU firmware, I think there's some precedent for users to expect it, so this leaves one less thing to look up and remember when trying out this platform project. If you don't like that change for some reason, I made it in a separate commit so it's easy to remove it from this branch, or you can just `git cherry-pick` the first commit if you like it. Just let me know.
